### PR TITLE
feat(security): add CodeQL + Dependabot [SUMMIT #411]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: "CodeQL"
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript-typescript', 'python']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- Add CodeQL static analysis workflow (runs on push to main, PRs, weekly Monday 6am UTC)
- Add Dependabot configuration for automated dependency updates (where missing)
- Enable secret scanning + push protection (where supported)

Part of SUMMIT #411 Phase B2 — security hardening across all repos.

## Test plan
- [ ] Verify CodeQL workflow runs on next push to main
- [ ] Verify Dependabot creates first batch of PRs within 24h
- [ ] Confirm no false positives in initial CodeQL scan

Generated by Claude Code (SUMMIT #411)